### PR TITLE
fix EdgeVirtualAddr flag

### DIFF
--- a/pkg/util/kubeadm/init.go
+++ b/pkg/util/kubeadm/init.go
@@ -295,7 +295,7 @@ func initClusterFlags(flagSet *flag.FlagSet, edgeConfig *cmd.EdgeadmConfig) {
 	)
 
 	flagSet.StringVar(
-		&edgeConfig.EdgeVirtualAddr, constant.EdgeVirtualAddr, constant.DefaultEdgeVirtualAddr, "Superedge related images registry, seperated from the default --image-repository (k8s.gcr.io).",
+		&edgeConfig.EdgeVirtualAddr, constant.EdgeVirtualAddr, constant.DefaultEdgeVirtualAddr, "Lite-apiserver listen address which is also used for coredns at edge node.",
 	)
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
comment
**What this PR does**:
fix EdgeVirtualAddr flag, Lite-apiserver listen address which is also used for coredns at edge node.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

