### PR TITLE
fix(lite-apiserver): After the edge node restarts, the dummy network …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
-	github.com/vishvananda/netlink v1.1.0
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.20.6

--- a/go.sum
+++ b/go.sum
@@ -564,10 +564,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=

--- a/pkg/edgeadm/constant/join.go
+++ b/pkg/edgeadm/constant/join.go
@@ -1,7 +1,6 @@
 package constant
 
 const (
-	KubeConfigPath        = "/root/.kube/config"
 	LiteAPIServerConfFile = SystemServiceDir + "lite-apiserver.service"
 )
 
@@ -11,6 +10,7 @@ Description=lite-apiserver
 
 [Service]
 Environment=QCLOUD_NORM_URL=
+ExecStartPre=-/bin/bash -c "ip link add tkeedgedns type dummy; ip addr add ${ADDRESS} dev tkeedgedns"
 ExecStart=/usr/bin/lite-apiserver \
 --ca-file=/etc/kubernetes/pki/lite-apiserver-ca.crt \
 --tls-cert-file=/etc/kubernetes/edge/lite-apiserver.crt \

--- a/pkg/edgeadm/steps/lite_apiserver_clean.go
+++ b/pkg/edgeadm/steps/lite_apiserver_clean.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/superedge/edgeadm/pkg/edgeadm/constant"
 	"github.com/superedge/edgeadm/pkg/util"
-	"github.com/vishvananda/netlink"
 )
 
 func NewCleanupLiteApiServerPhase() workflow.Phase {
@@ -55,7 +54,6 @@ func runCleanupLiteAPIServer(c workflow.RunData) error {
 	}
 	resetHostsFile()
 	resetConfigDir(constant.KubeEdgePath, constant.LiteAPIServerCACertPath)
-	err = resetDummy()
 	return err
 }
 
@@ -79,16 +77,6 @@ func resetHostsFile() error {
 	klog.V(1).Infof("[reset] Resetting file: %s\n", constant.HostsFilePath)
 	if _, _, err := util.RunLinuxCommand(constant.ResetDNSCmd); err != nil {
 		klog.Errorf("[reset] Failed to reset file: %s error: %v\n", constant.ResetDNSCmd, err)
-		return err
-	}
-	return nil
-}
-
-func resetDummy() error {
-	handle := &netlink.Handle{}
-	l, err := handle.LinkByName(constant.CorednsDummy)
-	if err == nil {
-		err = handle.LinkDel(l)
 		return err
 	}
 	return nil

--- a/pkg/edgeadm/steps/lite_apiserver_init.go
+++ b/pkg/edgeadm/steps/lite_apiserver_init.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/vishvananda/netlink"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -156,7 +155,6 @@ func deployLiteAPIServer(kubeClient *kubernetes.Clientset, data phases.JoinData)
 	if dummyIp == nil {
 		return fmt.Errorf("The Edge Node dummy NIC address is not specified")
 	}
-	err = ensureDummy(&netlink.Addr{IPNet: netlink.NewIPNet(dummyIp)})
 	if err != nil {
 		klog.Errorf("Failed to create dummy, error: %v", err)
 		return err
@@ -314,31 +312,6 @@ func addCloudNodeLabel(c workflow.RunData) error {
 
 	if err := kubeclient.AddNodeLabel(clientSet, data.Cfg().NodeRegistration.Name, masterLabel); err != nil {
 		klog.Errorf("Add Cloud Node node label error: %v", err)
-		return err
-	}
-	return nil
-}
-
-func ensureDummy(addr *netlink.Addr) error {
-	//dummy
-	handler := netlink.Handle{}
-	l, err := handler.LinkByName(constant.CorednsDummy)
-	if err == nil {
-		_ = handler.AddrAdd(l, addr)
-		return nil
-	}
-
-	dummy := &netlink.Dummy{
-		LinkAttrs: netlink.LinkAttrs{Name: constant.CorednsDummy},
-	}
-	err = handler.LinkAdd(dummy)
-	if err != nil {
-		return err
-	}
-
-	nl, _ := handler.LinkByName(constant.CorednsDummy)
-	err = handler.AddrAdd(nl, addr)
-	if err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
…card listened by lite-apiserver fails (#418)

<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
kind/bug
**What this PR does**:
After the edge node restarts, the dummy network card monitored by lite-apiserver fails
**Which issue(s) this PR fixes**:

[#418](https://github.com/superedge/superedge/issues/418)

