### PR TITLE
Add flag "--ignore-runtime" to edgeadm

### DIFF
--- a/pkg/edgeadm/cmd/model.go
+++ b/pkg/edgeadm/cmd/model.go
@@ -14,4 +14,5 @@ type EdgeadmConfig struct {
 	PodInfraContainer   string
 	EdgeImageRepository string
 	EdgeVirtualAddr     string
+	IgnoreRuntime       bool
 }

--- a/pkg/edgeadm/constant/options.go
+++ b/pkg/edgeadm/constant/options.go
@@ -12,6 +12,7 @@ const (
 	PodInfraContainerImage = "pod-infra-container-image"
 	EdgeImageRepository    = "edge-image-repository"
 	EdgeVirtualAddr        = "edge-virtual-addr"
+	IgnoreRuntime          = "ignore-runtime"
 )
 
 const (
@@ -21,7 +22,6 @@ const (
 	HANetworkDefaultInterface  = "eth0"
 	ContainerRuntimeDocker     = "docker"
 	ContainerRuntimeContainerd = "containerd"
-	ContainerRuntimeNone       = "none"
 
 	DefaultDockerCRISocket     = "/var/run/dockershim.sock"
 	DefaultContainerdCRISocket = "/run/containerd/containerd.sock"

--- a/pkg/edgeadm/constant/options.go
+++ b/pkg/edgeadm/constant/options.go
@@ -21,6 +21,7 @@ const (
 	HANetworkDefaultInterface  = "eth0"
 	ContainerRuntimeDocker     = "docker"
 	ContainerRuntimeContainerd = "containerd"
+	ContainerRuntimeNone       = "none"
 
 	DefaultDockerCRISocket     = "/var/run/dockershim.sock"
 	DefaultContainerdCRISocket = "/run/containerd/containerd.sock"

--- a/pkg/edgeadm/steps/runtime.go
+++ b/pkg/edgeadm/steps/runtime.go
@@ -45,6 +45,12 @@ func NewContainerPhase() workflow.Phase {
 }
 
 func installContainer(c workflow.RunData) error {
+
+	if EdgeadmConf.IgnoreRuntime {
+		klog.Infof("Ignore to install the runtime %s ", EdgeadmConf.ContainerRuntime)
+		return nil
+	}
+
 	switch EdgeadmConf.ContainerRuntime {
 	case constant.ContainerRuntimeDocker:
 		if err := installDocker(); err != nil {
@@ -54,9 +60,6 @@ func installContainer(c workflow.RunData) error {
 		if err := installContainerd(); err != nil {
 			return err
 		}
-	case constant.ContainerRuntimeNone:
-		//nothing todo
-		klog.Infof("Ignore the runtime")
 	}
 	klog.Infof("Installed container runtime %s successfully", EdgeadmConf.ContainerRuntime)
 

--- a/pkg/edgeadm/steps/runtime.go
+++ b/pkg/edgeadm/steps/runtime.go
@@ -54,6 +54,9 @@ func installContainer(c workflow.RunData) error {
 		if err := installContainerd(); err != nil {
 			return err
 		}
+	case constant.ContainerRuntimeNone:
+		//nothing todo
+		klog.Infof("Ignore the runtime")
 	}
 	klog.Infof("Installed container runtime %s successfully", EdgeadmConf.ContainerRuntime)
 

--- a/pkg/util/kubeadm/init.go
+++ b/pkg/util/kubeadm/init.go
@@ -19,15 +19,16 @@ package kubeadm
 
 import (
 	"fmt"
-	"github.com/superedge/edgeadm/pkg/util/kubeclient"
 	"io"
-	kubeadmapiv1beta3 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"net"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/superedge/edgeadm/pkg/util/kubeclient"
+	kubeadmapiv1beta3 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 
 	"github.com/lithammer/dedent"
 	"github.com/pkg/errors"
@@ -219,6 +220,8 @@ func NewInitCMD(out io.Writer, edgeConfig *cmd.EdgeadmConfig) *cobra.Command {
 			initOptions.externalInitCfg.NodeRegistration.CRISocket = constant.DefaultDockerCRISocket
 		case constant.ContainerRuntimeContainerd:
 			initOptions.externalInitCfg.NodeRegistration.CRISocket = constant.DefaultContainerdCRISocket
+		case constant.ContainerRuntimeNone:
+			initOptions.externalInitCfg.NodeRegistration.CRISocket = constant.DefaultDockerCRISocket
 		default:
 			return fmt.Errorf("Container runtime support 'docker' and 'containerd', not %s\n", edgeConfig.ContainerRuntime)
 		}

--- a/pkg/util/kubeadm/init.go
+++ b/pkg/util/kubeadm/init.go
@@ -220,8 +220,6 @@ func NewInitCMD(out io.Writer, edgeConfig *cmd.EdgeadmConfig) *cobra.Command {
 			initOptions.externalInitCfg.NodeRegistration.CRISocket = constant.DefaultDockerCRISocket
 		case constant.ContainerRuntimeContainerd:
 			initOptions.externalInitCfg.NodeRegistration.CRISocket = constant.DefaultContainerdCRISocket
-		case constant.ContainerRuntimeNone:
-			initOptions.externalInitCfg.NodeRegistration.CRISocket = constant.DefaultDockerCRISocket
 		default:
 			return fmt.Errorf("Container runtime support 'docker' and 'containerd', not %s\n", edgeConfig.ContainerRuntime)
 		}
@@ -307,6 +305,11 @@ func initContainerRuntimeFlags(flagSet *flag.FlagSet, edgeConfig *cmd.EdgeadmCon
 	flagSet.StringVar(
 		&edgeConfig.ContainerRuntime, constant.ContainerRuntime,
 		constant.ContainerRuntimeContainerd, "Container runtime support docker and containerd.",
+	)
+
+	flagSet.BoolVar(
+		&edgeConfig.IgnoreRuntime, constant.IgnoreRuntime,
+		false, "If execute runtime installation, default false.",
 	)
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**

**What this PR does**:
Add a flag "--ignore-runtime" to edgeadm, so that edgeadm doesn't install embeded docker/containerd
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

