### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/pkg/edgeadm/cmd/addon/edgeapps.go
+++ b/pkg/edgeadm/cmd/addon/edgeapps.go
@@ -47,11 +47,11 @@ func NewInstallEdgeAppsCMD() *cobra.Command {
 	)
 
 	cmd.Flags().StringVar(
-		&action.edgeadmConfig.EdgeImageRepository, constant.EdgeImageRepository, constant.ImageRepository, "Superedge related images registry, seperated from the default --image-repository (k8s.gcr.io).",
+		&action.edgeadmConfig.EdgeImageRepository, constant.EdgeImageRepository, constant.ImageRepository, "Superedge related images registry, seperated from the default --image-repository (registry.k8s.io).",
 	)
 
 	cmd.Flags().StringVar(
-		&action.edgeadmConfig.EdgeVirtualAddr, constant.EdgeVirtualAddr, constant.DefaultEdgeVirtualAddr, "Superedge related images registry, seperated from the default --image-repository (k8s.gcr.io).",
+		&action.edgeadmConfig.EdgeVirtualAddr, constant.EdgeVirtualAddr, constant.DefaultEdgeVirtualAddr, "Superedge related images registry, seperated from the default --image-repository (registry.k8s.io).",
 	)
 	return cmd
 }

--- a/pkg/util/kubeadm/init.go
+++ b/pkg/util/kubeadm/init.go
@@ -283,7 +283,7 @@ func initClusterFlags(flagSet *flag.FlagSet, edgeConfig *cmd.EdgeadmConfig) {
 	)
 
 	flagSet.StringVar(
-		&edgeConfig.EdgeImageRepository, constant.EdgeImageRepository, constant.ImageRepository, "Superedge related images registry, seperated from the default --image-repository (k8s.gcr.io).",
+		&edgeConfig.EdgeImageRepository, constant.EdgeImageRepository, constant.ImageRepository, "Superedge related images registry, seperated from the default --image-repository (registry.k8s.io).",
 	)
 
 	flagSet.StringVar(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

